### PR TITLE
Update supported runtimes & python dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ## Unreleased - 1.1.0-dev.1
 
+### Added
+- Supported runtime Python 3.8
+
 ### Changed
-- Upgraded packages
+- Upgraded builder packages
+- Upgraded handler packages
 - Moved all `@now/` prefixed build utilities to `@vercel/` prefix
 - Renamed package to `vercel-python-wsgi`
+
+### Removed
+- Runtime Python 2.7 (no longer supported by Vercel)
 
 
 ## [1.0.11] - 2019-11-03 - Upgrade eslint-utils & werkzeug

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ then you can configure it as the entrypoint and adjust routes accordingly:
 
 ### Lambda environment limitations
 
-At the time of writing, Zeit Now runs on AWS Lambda. This has a number of
+At the time of writing, Vercel runs on AWS Lambda. This has a number of
 implications on what libaries will be available to you, notably:
 
 - PostgreSQL, so psycopg2 won't work out of the box

--- a/build-utils/python.js
+++ b/build-utils/python.js
@@ -4,8 +4,8 @@ const log = require('./log');
 
 
 const runtimeBinaryMap = {
-  'python2.7': 'python27',
   'python3.6': 'python3.6',
+  'python3.8': 'python3.8',
 };
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
         'vercel_python_wsgi'
     ],
     install_requires=[
-        'Werkzeug==0.16.0',
+        'Werkzeug==1.0.1',
     ]
 )


### PR DESCRIPTION
### Added
- Supported runtime Python 3.8

### Changed
- Upgraded handler packages

### Removed
- Runtime Python 2.7 (no longer supported by Vercel)